### PR TITLE
gave difficult antags time requirements

### DIFF
--- a/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
@@ -4,6 +4,13 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-heretic-description
+  requirements:
+  - !type:DepartmentTimeRequirement
+  department: Security
+  time: 36000 # 10h
+  - !type:DepartmentTimeRequirement
+  department: Medical
+  time: 36000 # 10h
   guides: [ Heretics ]
 
 - type: startingGear


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Heretic, Changeling, and headrev now have time requirements.

## Why / Balance
I keep seeing lings / heretics / headrevs not know how to do their roles / where to get organs / what a flash is. Adding these time requirements will require players to play the departments that they would have to interact with in order to complete their goals. Will also likely help fix the lack of security.